### PR TITLE
Parse typed values from enum

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,9 +149,15 @@ var CheckBox = React.createClass({
 var Selection = React.createClass({
   displayName: 'Selection',
 
+  normalize: function(text) {
+    return normalizer[this.props.type](text);
+  },
+  parse: function(text) {
+    return parser[this.props.type](text);
+  },
   handleChange: function(event) {
-    var val = event.target.value;
-    this.props.update(this.props.path, val, val);
+    var val = this.normalize(event.target.value);
+    this.props.update(this.props.path, val, this.parse(val));
   },
   render: function() {
     var names = this.props.names;


### PR DESCRIPTION
Enum fields can have a type, for example set to `integer`, but are currently always being submitted as strings.

This fix just mirrors the parsing and normalizing logic from other type of fields. Actually, since the values can never be entered by the user, parsing shouldn't be necessary (but I left it in for symmetry).

An alternative way of fixing this would be to do a type-agnostic lookup in the enumerated values from the schema, and return that one (it should have the proper type). But I like the submitted fix better.