### PR TITLE
Set up a basic demo site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+*.log
+gh-pages/
 node_modules/

--- a/config/deploy-gh-pages.js
+++ b/config/deploy-gh-pages.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var ghpages = require('gh-pages');
+
+var config = require('./webpack.gh-pages');
+
+
+main();
+
+function main() {
+    ghpages.publish(config.output.path, console.error.bind(console));
+}

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -1,0 +1,22 @@
+'use strict';
+
+
+module.exports = {
+    entry: [
+        './demos/index'
+    ],
+    resolve: {
+        extensions: ['', '.js', '.jsx', '.md', '.css'],
+    },
+};
+
+module.exports.loaders = [
+    {
+        test: /\.css$/,
+        loaders: ['style', 'css'],
+    },
+    {
+        test: /\.md$/,
+        loader: 'html!../loaders/markdown',
+    },
+];

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -1,0 +1,30 @@
+'use strict';
+var extend = require('xtend');
+var webpack = require('webpack');
+
+var common = require('./webpack.common');
+
+
+module.exports = extend(common, {
+    devtool: 'eval',
+    entry: [
+        'webpack-dev-server/client?http://0.0.0.0:3000',
+        'webpack/hot/only-dev-server',
+        './demos/index',
+    ],
+    output: {
+        path: __dirname,
+        filename: 'bundle.js',
+        publicPath: '/demos/'
+    },
+    plugins: [
+        new webpack.HotModuleReplacementPlugin(),
+        new webpack.NoErrorsPlugin(),
+    ],
+    module: {
+        loaders: common.loaders.concat([{
+            test: /\.jsx?$/,
+            loaders: ['react-hot', 'jsx-loader?harmony'],
+        }])
+    }
+});

--- a/config/webpack.gh-pages.js
+++ b/config/webpack.gh-pages.js
@@ -1,0 +1,42 @@
+'use strict';
+// adapted based on https://github.com/gpbl/isomorphic-react-template
+var extend = require('xtend');
+var webpack = require('webpack');
+var HtmlWebpackPlugin = require('html-webpack-plugin');
+
+var common = require('./webpack.common');
+var pkg = require('../package.json');
+
+
+module.exports = extend(common, {
+    entry: [
+        './demos/index'
+    ],
+    output: {
+        path: './gh-pages',
+        filename: 'bundle.js',
+    },
+    plugins: [
+        new webpack.DefinePlugin({
+            'process.env': {
+                // This has effect on the react lib size
+                'NODE_ENV': JSON.stringify('production'),
+            }
+        }),
+        new webpack.optimize.DedupePlugin(),
+        new webpack.optimize.UglifyJsPlugin({
+            compress: {
+                warnings: false
+            },
+        }),
+        new HtmlWebpackPlugin({
+            title: pkg.name + ' - ' + pkg.description
+        }),
+    ],
+    module: {
+        loaders: common.loaders.concat([{
+            test: /\.jsx?$/,
+            loaders: ['jsx-loader?harmony'],
+        }])
+    }
+});

--- a/demos/app.js
+++ b/demos/app.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var React = require('react');
+var Fork = require('react-ghfork');
+
+var Demo = require('./demo.jsx');
+
+var readme = require('../README.md');
+
+
+module.exports = React.createClass({
+    render() {
+        return <div className='pure-g'>
+            <Fork className='right' project='AppliedMathematicsANU/plexus-form'></Fork>
+            <header className='pure-u-1'>
+                <h1>plexus-form</h1>
+
+                <div className='description'>A dynamic form component for react using JSON-Schema.</div>
+            </header>
+            <article className='pure-u-1'>
+                <section className='demonstration'>
+                    <div className='description'>
+                        <h2>Demonstration</h2>
+
+                        <p>Tweak the schema and form below</p>
+
+                        <Demo></Demo>
+                    </div>
+                </section>
+                <section className='documentation'>
+                    <h2>README</h2>
+
+                    <div dangerouslySetInnerHTML={{__html: readme}}></div>
+                </section>
+            </article>
+        </div>;
+    },
+});

--- a/demos/demo.css
+++ b/demos/demo.css
@@ -1,0 +1,87 @@
+*, *:before, *:after {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+html {
+    font-size: 13px;
+    font-family: arial, sans-serif;
+}
+
+.flexContainer {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+.flexItem {
+  margin-right: 20px;
+}
+
+.error, .error * {
+    color: red;
+}
+
+.form-section {
+    border: 2px solid gray;
+}
+
+.form-subsection {
+    border: none;
+    padding: 0;
+    margin: 0.5em 0;
+}
+
+.form-section-title {
+    font-weight: bold;
+}
+
+.form-subsection .form-section-title {
+    padding: 5px 0;
+}
+
+.form-element {
+    position: relative;
+}
+
+.form-element label {
+    width: 10em;
+    display: inline-block;
+}
+
+.form-section dt {
+    float: left;
+    width: 5em;
+}
+
+.form-section dd {
+    margin-left: 5em;
+}
+
+.form-help, .form-error {
+    display: inline-block;
+    border: thin solid;
+    border-radius: 50%;
+    margin: 0 2px;
+}
+
+.form-help {
+    padding: 0 4px;
+}
+
+.form-error {
+    padding: 0 6px;
+}
+
+.invisible {
+    visibility: hidden;
+}
+
+.hidden {
+    display: none;
+}

--- a/demos/demo.jsx
+++ b/demos/demo.jsx
@@ -1,0 +1,270 @@
+'use strict';
+
+var React = require('react');
+
+var validate = require('plexus-validate');
+var Form     = require('..');
+
+
+var schema = {
+  definitions: {
+    weight: {
+      title: "Weight",
+      type: "object",
+      properties: {
+        amount: {
+          type: "number",
+          minimum: 0,
+          exclusiveMinimum: true
+        },
+        unit: {
+          enum: [ "kg", "lbs" ],
+          // optional, see https://github.com/json-schema/json-schema/wiki/enumNames-(v5-proposal)
+          // this is handy for i18n since then you want to separate values/names
+          enumNames: [ "KG", "lbs"]
+        }
+      }
+    }
+  },
+  title: "Example form",
+  description: "A form based on a schema",
+  type: "object",
+  required: ["name", "age"],
+  'x-hints': {
+    form: {
+      classes: 'my-nice-form'
+    }
+  },
+  properties: {
+    name: {
+      title: "Your name",
+      description: "Your full name",
+      type: "string",
+      minLength: 3,
+      maxLength: 40,
+      pattern: "^[A-Z][a-z]*(\\s[A-Z][a-z]*)*$",
+      'x-hints': {
+        form: {
+          classes: 'important-field'
+        }
+      }
+    },
+    age: {
+      title: "Your age",
+      type: "integer",
+      minimum: 1
+    },
+    weight: {
+      title: "Your weight",
+      "$ref": "#/definitions/weight"
+    },
+    color: {
+      title: "Favourite colour",
+      type: "object",
+      properties: {
+        hasFave: {
+          title: "Do you have a favourite colour?",
+          type: "string"
+        }
+      },
+      oneOf: [
+        {
+        },
+        {
+          properties: {
+            hasFave: {
+              enum: [ "no" ]
+            }
+          }
+        },
+        {
+          properties: {
+            hasFave: {
+              enum: [ "yes" ]
+            },
+            fave: {
+              title: "Your favourite colour",
+              type: "string",
+              enum: [
+                "", "red", "green", "blue", "yellow", "orange", "purple", "other"
+              ]
+            }
+          }
+        }
+      ],
+      "x-hints": {
+        form: {
+          selector: "hasFave",
+        }
+      }
+    },
+    interests: {
+      title: "Your interests",
+      type: "array",
+      minItems: 2,
+      items: {
+        type: "string",
+        minLength: 2
+      }
+    },
+    languages: {
+      title: "Languages you speak",
+      type: "array",
+      maxItems: 2,
+      items: {
+        type: "string"
+      }
+    },
+    motto: {
+      title: "Your motto (file upload)",
+      type: "object",
+      "x-hints": {
+        "fileUpload": {
+          "mode": "text"
+        },
+        "form": {
+          classes: "important-file"
+        }
+      },
+      properties: {
+        caption: {
+          title: "Caption",
+          type: "string"
+        }
+      }
+    }
+  }
+};
+
+
+var SchemaEditor = React.createClass({
+  displayName: 'SchemaEditor',
+
+  preventSubmit: function(event) {
+    event.preventDefault();
+  },
+  render: function() {
+    return (
+      <form onSubmit={this.preventSubmit}>
+        <textarea rows="30" cols="60" onChange={this.props.onChange} value={this.props.value}></textarea>
+      </form>
+    );
+  }
+});
+
+
+var FieldWrapper = React.createClass({
+  render: function() {
+    var errors  = (this.props.errors || []).join('\n');
+    var classes = [].concat(errors ? 'error' : [],
+                            'form-element',
+                            this.props.classes || []);
+    var helpClasses  =
+      'form-help' + (this.props.description ? '' : ' invisible');
+    var errorClasses =
+      'form-error' + (errors ? '' : ' invisible');
+
+    return (
+        <div className={classes.join(' ')} key={this.props.key}>
+          <label htmlFor={this.props.key}>
+            {this.props.title}
+          </label>
+          <span className={helpClasses} title={this.props.description}>
+            ?
+          </span>
+          {this.props.children}
+          <span className={errorClasses} title={errors}>
+            !
+          </span>
+        </div>
+    );
+  }
+});
+
+
+var SectionWrapper = React.createClass({
+  render: function() {
+    var errors  = (this.props.errors || []).join('\n');
+    var level = this.props.path.length;
+    var classes = [].concat(errors ? 'error' : [],
+                            'form-section',
+                            (level > 0 ? 'form-subsection' : []),
+                            this.props.classes || []);
+    var helpClasses  =
+      'form-help' + (this.props.description ? '' : ' hidden');
+    var errorClasses =
+      'form-error' + (errors ? '' : ' hidden');
+
+    return (
+        <fieldset className={classes.join(' ')} key={this.props.key}>
+          <legend className="form-section-title">
+            {this.props.title}
+            <span className={helpClasses} title={this.props.description}>
+              ?
+            </span>
+            <span className={errorClasses} title={errors}>
+              !
+            </span>
+          </legend>
+          {this.props.children}
+        </fieldset>
+    );
+  }
+});
+
+
+module.exports = React.createClass({
+  displayName: 'FormDemoPage',
+
+  getInitialState: function() {
+    return {
+      schema: schema,
+      text  : JSON.stringify(schema, null, 2)
+    };
+  },
+  update: function(event) {
+    var text = event.target.value;
+    var schema;
+    try {
+      schema = JSON.parse(event.target.value);
+      this.setState({ schema: schema, text: text });
+    } catch (ex) {
+      this.setState({ text: text });
+    }
+  },
+  onFormSubmit: function(data, value, errors) {
+    this.setState({ button: value, data: data, errors: errors });
+  },
+  render: function() {
+    return (
+      <div>
+        <ul className="flexContainer">
+          <li className="flexItem">
+            <h3>Schema:</h3>
+            <SchemaEditor value={this.state.text} onChange={this.update} />
+          </li>
+          <li className="flexItem">
+            <h3>Generated form:</h3>
+            <Form buttons={['Dismissed', 'Energise']}
+              onSubmit={this.onFormSubmit}
+              schema={this.state.schema}
+              validate={validate}
+              fieldWrapper={FieldWrapper}
+              sectionWrapper={SectionWrapper}
+            />
+          </li>
+          <li className="flexItem">
+            <h3>Data:</h3>
+            <pre>{JSON.stringify(this.state.data, null, 4)}</pre>
+
+            <h3>Button:</h3>
+            <p>{this.state.button}</p>
+
+            <h3>Errors:</h3>
+            <pre>{JSON.stringify(this.state.errors, null, 4)}</pre>
+          </li>
+        </ul>
+      </div>
+    );
+  }
+});

--- a/demos/index.js
+++ b/demos/index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+require('purecss/pure.css');
+require('highlight.js/styles/github.css');
+require('react-ghfork/gh-fork-ribbon.ie.css');
+require('react-ghfork/gh-fork-ribbon.css');
+require('./main.css');
+require('./demo.css');
+
+
+var React = require('react'),
+    App = require('./app');
+
+
+React.render(<App />, document.body);

--- a/demos/main.css
+++ b/demos/main.css
@@ -1,0 +1,73 @@
+body {
+    background: #fefefe;
+
+    font-family: Sans-Serif;
+
+    line-height: 1.5;
+}
+
+form label {
+    display: block;
+}
+
+header {
+    z-index: 1000;
+
+    position: fixed;
+    padding: 0.5em;
+
+    text-align: center;
+
+    color: #333;
+    border: 0.1em solid #bbb;
+
+    background: #ded;
+}
+
+header h1 {
+    margin: 0;
+}
+
+header .description {
+    color: #888;
+}
+
+.sticky {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+}
+
+.github-fork-ribbon {
+    position: fixed;
+
+    letter-spacing: 0.01em;
+}
+
+article {
+    display: block !important;
+
+    margin-top: 6em;
+    margin-left: auto;
+    margin-right: auto;
+
+    max-width: 768px;
+}
+
+article section {
+    margin-bottom: 2em;
+}
+
+article h2 {
+    margin-top: 2em;
+}
+
+textarea {
+    width: 100%;
+}
+
+pre {
+    background: #fafefe;
+    padding: 0.5em;
+}

--- a/demos/main.css
+++ b/demos/main.css
@@ -15,6 +15,7 @@ header {
 
     position: fixed;
     padding: 0.5em;
+    top: 0;
 
     text-align: center;
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>plexus-form - A dynamic form component for react using JSON-Schema</title>
+  </head>
+  <body>
+  </body>
+  <script src="/demos/bundle.js"></script>
+</html>

--- a/loaders/markdown.js
+++ b/loaders/markdown.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var marked = require('marked');
+var highlight = require('highlight.js');
+
+marked.setOptions({
+    highlight: function(code) {
+        return highlight.highlightAuto(code).value;
+    }
+});
+
+
+module.exports = function(markdown) {
+    this.cacheable();
+
+    return marked(markdown);
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node server.js",
     "gh-pages": "webpack --config ./config/webpack.gh-pages.js",
-    "deploy-gh-pages": "node ./config/deploy-gh-pages.js",
+    "deploy-gh-pages": "scripts/deploy.sh",
     "dist": "webpack --config ./config/webpack.dist.js && webpack --config ./config/webpack.dist.min.js"
   },
   "keywords": [
@@ -37,7 +37,6 @@
   "devDependencies": {
     "css-loader": "^0.9.1",
     "file-loader": "^0.8.1",
-    "gh-pages": "^0.2.0",
     "highlight.js": "^8.4.0",
     "html-loader": "^0.2.3",
     "html-webpack-plugin": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "A dynamic form component for react using JSON-Schema.",
   "scripts": {
+    "start": "node server.js",
+    "gh-pages": "webpack --config ./config/webpack.gh-pages.js",
+    "deploy-gh-pages": "node ./config/deploy-gh-pages.js",
     "dist": "webpack --config ./config/webpack.dist.js && webpack --config ./config/webpack.dist.min.js"
   },
   "keywords": [
@@ -32,8 +35,22 @@
     "url": "https://github.com/AppliedMathematicsANU/plexus-form.git"
   },
   "devDependencies": {
+    "css-loader": "^0.9.1",
+    "file-loader": "^0.8.1",
+    "gh-pages": "^0.2.0",
+    "highlight.js": "^8.4.0",
+    "html-loader": "^0.2.3",
+    "html-webpack-plugin": "^1.1.0",
     "jsx-loader": "^0.12.2",
+    "marked": "^0.3.3",
+    "plexus-validate": "0.0.4",
+    "purecss": "^0.5.0",
+    "react-ghfork": "^0.2.2",
+    "react-hot-loader": "^1.1.6",
+    "style-loader": "^0.8.3",
+    "url-loader": "^0.5.5",
     "webpack": "^1.6.0",
+    "webpack-dev-server": "^1.7.0",
     "xtend": "^4.0.0"
   }
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# this script expects that a gh-pages build exists already
+# adapted from https://gist.github.com/domenic/ec8b0fc8ab45f39403dd
+
+# go to the out directory and create a *new* Git repo
+cd gh-pages
+
+# Remove possible existing git repo. We'll replace entire gh-pages.
+rm -rf .git
+
+# Init new repo
+git init
+
+# The first and only commit to this new Git repo contains all the
+# files present with the commit message "Deploy to GitHub Pages".
+git add .
+git commit -m "Deploy to GitHub Pages"
+
+# Add origin
+git remote add origin git@github.com:AppliedMathematicsANU/plexus-form.git
+
+# Force push from the current repo's master branch to the remote
+# repo's gh-pages branch. (All previous history on the gh-pages branch
+# will be lost, since we are overwriting it.)
+git push --force origin master:gh-pages

--- a/server.js
+++ b/server.js
@@ -1,0 +1,17 @@
+'use strict';
+var webpack = require('webpack');
+var WebpackDevServer = require('webpack-dev-server');
+
+var config = require('./config/webpack.config');
+
+
+new WebpackDevServer(webpack(config), {
+    publicPath: config.output.publicPath,
+    hot: true
+}).listen(3000, '0.0.0.0', function (err) {
+    if(err) {
+        return console.log(err);
+    }
+
+    console.log('Listening at 0.0.0.0:3000');
+});


### PR DESCRIPTION
To start developing against it (hot loading) hit `npm start`. You can generate `gh-pages` using `npm run gh-pages`. It can be deployed to the `gh-pages` branch by hitting `npm run deploy-gh-pages`.

The demo site has been split in two parts. The upper half is meant for a basic demo. I just copied the one that exists already. In addition you could render each field here in a separate section. The lower half just renders README.md (highlighting applied).

Related to #23.