### PR TITLE
Allow errorClass to survive undefined

### DIFF
--- a/lib/fields/utils/wrapped.js
+++ b/lib/fields/utils/wrapped.js
@@ -7,7 +7,7 @@ var ou = require('plexus-objective');
 
 
 var errorClass = function(errors) {
-  if(!errors || errors === null || errors.length === 0) {
+  if(!errors || errors.length === 0) {
     return '';
   }
 

--- a/lib/fields/utils/wrapped.js
+++ b/lib/fields/utils/wrapped.js
@@ -7,7 +7,11 @@ var ou = require('plexus-objective');
 
 
 var errorClass = function(errors) {
-  return (errors === null || errors.length === 0) ? '' : 'error';
+  if(!errors || errors === null || errors.length === 0) {
+    return '';
+  }
+
+  return 'error';
 };
 
 var makeTitle = function(description, errors) {


### PR DESCRIPTION
Just noticed `errorClass` generator can fail if `props.errors` is undefined. It's another question why that can happen in the first place of course.