### PR TITLE
Update react dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "plexus-objective": "~0.0.1"
   },
   "peerDependencies": {
-    "react": "^0.12.2"
+    "react": ">=0.12.2 <1.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "plexus-objective": "~0.0.1"
   },
   "peerDependencies": {
-    "react": "~0.12.2"
+    "react": "^0.12.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
If react 0.13 used in project. This package cause error
`Uncaught TypeError: Can't add property context, object is not extensible`
because install and use different version.