### PR TITLE
Allow errors and description to be undefined

### DIFF
--- a/lib/fields/utils/wrapped.js
+++ b/lib/fields/utils/wrapped.js
@@ -16,10 +16,10 @@ var errorClass = function(errors) {
 
 var makeTitle = function(description, errors) {
   var parts = [];
-  if (description !== null && description.length > 0) {
+  if (description && description.length > 0) {
     parts.push(description);
   }
-  if (errors !== null && errors.length > 0) {
+  if (errors && errors.length > 0) {
     parts.push(errors.join('\n'));
   }
   return parts.join('\n\n');


### PR DESCRIPTION
Regression introduced by faaff6e and fix similar to e42725a.

For an example of what this fixes, see the `TypeError` [being raised here](https://gist.github.com/martijnvermaat/292ecd6e912a3edd89c1).