### PR TITLE
Update react-ghfork from ^0.2.2 to ^0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "marked": "^0.3.3",
     "plexus-validate": "0.0.4",
     "purecss": "^0.5.0",
-    "react-ghfork": "^0.2.2",
+    "react-ghfork": "^0.3.0",
     "react-hot-loader": "^1.1.6",
     "style-loader": "^0.8.3",
     "url-loader": "^0.5.5",


### PR DESCRIPTION
Fixes incompatibilities in peer dependencies.

```
$ git clone https://github.com/AppliedMathematicsANU/plexus-form.git
$ cd plexus-form/
$ npm install

...

npm WARN optional dep failed, continuing fsevents@0.3.6
npm ERR! Linux 3.2.0-4-amd64
npm ERR! argv "/usr/bin/iojs" "/usr/bin/npm" "install"
npm ERR! node v1.3.0
npm ERR! npm  v2.5.1
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package react does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-ghfork@0.2.2 wants react@^0.12.2
npm ERR! peerinvalid Peer react-hot-loader@1.2.7 wants react@>=0.11.0

npm ERR! Please include the following file with any support request:
npm ERR!     /tmp/plexus-form/npm-debug.log
```